### PR TITLE
Install instructions for Composer

### DIFF
--- a/install.markdown
+++ b/install.markdown
@@ -102,18 +102,18 @@ php composer.phar install
 From now on Codeception (with installed PHPUnit) can be run as:
 
 {% highlight bash %}
-php vendor/bin/codecept
+vendor/bin/codecept
 {% endhighlight %}
 
 Initialize your testing environment with 
 
 {% highlight bash %}
-php vendor/bin/codecept bootstrap
+vendor/bin/codecept bootstrap
 {% endhighlight %}
 
 Run test suite:
 
 {% highlight bash %}
-php vendor/bin/codecept run
+vendor/bin/codecept run
 {% endhighlight %}
 


### PR DESCRIPTION
The instructions tell to run codeception as if it was a PHP script or PHAR .

``` bash
php vendor/bin/codecept
```

When you take a look into the vendor/bin directory you will not find any PHP code.
Instead the composer package comes with *nix shell scripts and Windows batch files for both codeception and phpunit.

That won't work! PHP can neither run shell scripts nor batch files!
I stripped the php in front and everything works as expected!
