### PR TITLE
Fix about copyright dates (current year)

### DIFF
--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -157,8 +157,7 @@
       </div>
     </div>
 <div id="copyright">
-  &copy; 2011 - &lt;?php date('Y') ?>
-  <!-- You broke my PHP, man! -->
+  &copy; 2011 - <?php echo date('Y') ?>
 </div>  
 
 


### PR DESCRIPTION
Fixed a problem with HTML encoding and fixed also to print properly the current year for the copyright date range.
