### PR TITLE
Update 404 link to correct URL

### DIFF
--- a/_includes/reference.html
+++ b/_includes/reference.html
@@ -1,5 +1,5 @@
 <li><a href="/docs/reference/commands">Commands</a></li>
 <li><a href="/docs/reference/configuration">Configuration</a></li>
-<li><a href="/09-23-2012/locator.html">Locators (complex CSS, XPath)</a></li>
+<li><a href="/09-24-2012/locator.html">Locators (complex CSS, XPath)</a></li>
 <li><a href="/docs/reference/xmlbuilder">Xml Builder</a></li>
 <li><a href="/docs/reference/stubs">Stubs</a></li>


### PR DESCRIPTION
Some time ago the blog entries were all bumped up a day, not sure why!?

This URL was pointing to a missing resource, therefore causing a 404 error
