### PR TITLE
Fix date in URL

### DIFF
--- a/_includes/reference.html
+++ b/_includes/reference.html
@@ -1,5 +1,5 @@
 <li><a href="/docs/reference/commands">Commands</a></li>
 <li><a href="/docs/reference/configuration">Configuration</a></li>
-<li><a href="/09-24-2012/locator.html">Locators (complex CSS, XPath)</a></li>
+<li><a href="/09-23-2012/locator.html">Locators (complex CSS, XPath)</a></li>
 <li><a href="/docs/reference/xmlbuilder">Xml Builder</a></li>
 <li><a href="/docs/reference/stubs">Stubs</a></li>


### PR DESCRIPTION
Looks like all the blog posts have (once again) moved by one calendar day, update the link accordingly
