### PR TITLE
fix anchors in TOC for headings with 2+ spaces

### DIFF
--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -30,12 +30,11 @@ layout: bootstrap
     <script type="text/javascript">
     $(document).ready(function () {
       $('#toc').toc({
-        'selectors': 'h2,h3,h4',
-        'prefix': 'toc',
-        'container': '#page',
-    'anchorName': function(i, heading, prefix) { //custom function for anchor name
-      return $(heading).text().replace(' ','-');
-    },    
+        selectors: 'h2,h3,h4',
+        container: '#page',
+        anchorName: function (i, heading, prefix) {
+          return $(heading).text().replace(/\s/g, '-').replace(/[^\w-]/g, '');
+        },    
   });
     });
     </script>


### PR DESCRIPTION
For example, "Sample acceptance test" produces anchor name "#Sample-acceptance test" which is incorrect, so links don't work.
Old `replace()` replaced only the first space character.
