### PR TITLE
Fix footer missing year

### DIFF
--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -182,8 +182,11 @@
       </div>
     </div>
 <div id="copyright">
-  © 2011&ndash;<span data-toggle="tooltip" alt="" title="YOU BROKE MY PHP! FIX IT ASAP!">&lt;?= date('Y') ?&gt;</span>
-  <!-- You broke my PHP, man! -->
+  © 2011&ndash;
+  <script type="text/javascript">
+	var currentYear = new Date().getFullYear();
+	document.write(currentYear);
+  </script>
 </div>  
 
 
@@ -209,3 +212,5 @@
   
 
   </body></html>
+  
+  


### PR DESCRIPTION
I think this should fix the broken footer:

![screen shot 2014-07-24 at 11 06 17](https://cloud.githubusercontent.com/assets/1375475/3685937/94933138-1311-11e4-9ec5-0c1bdf917d58.png)

Thanks

Codeception rocks!
