### PR TITLE
Add Phantoman to list of 3rd Party Extensions

### DIFF
--- a/addons.markdown
+++ b/addons.markdown
@@ -79,6 +79,10 @@ Extensions should be installed via **Composer**.
 
 Extension for starting and stopping built-in PHP server. Works on Windows, Mac, Linux.
 
+#### [Phantoman](https://github.com/site5/phantoman)
+
+Extension for automatically starting and stopping PhantomJS when running tests.
+
 #### [DrushDb](https://github.com/pfaocle/DrushDb)
 
 DrushDb is a Codeception extension to populate and cleanup test **Drupal** sites during test runs using Drush aliases and the sql-sync command.


### PR DESCRIPTION
[Phantoman](https://github.com/site5/phantoman) is a newer Codeception extension responsible for automatically starting and stopping PhantomJS around tests. PhantomJS is spun up before test run and stopped afterwards. This extension works really well with PHPBuiltinServer to make a fully self contained testing package.
