### PR TITLE
Information about how to run specific tests in a class

### DIFF
--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -187,7 +187,7 @@ $ php codecept.phar run tests/acceptance/SigninCept.php
 
 {% endhighlight %}
 
-You can execute one test from a test class (for Cest or Test formats)
+You can execute one test from a test class (for Cest or Test formats). Works in a similar way to phpunit's --filter option
 
 {% highlight bash %}
 


### PR DESCRIPTION
My wording probably isn't the best but I think it would be helpful to explain that running something like

``` bash
php codecept.phar  tests/acceptance/SignInCest.php:testLogin
```

...actually runs

``` bash
SignInCest.php:testLogin
SignInCest.php:testLoginFails
SignInCest.php:testLoginSuccess
```

I think this is because it works how phpunit's --filter option works