### PR TITLE
Fix broken link in Getting Started section

### DIFF
--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -155,7 +155,7 @@ Each suite has its own bootstrap file. It's located in the suite directory and i
 
 ## Cept, Cest and Test Formats
 
-Codeception supports three test formats. Beside the previously described scenario-based Cept format, Codeception can also execute [PHPUnit test files for unit testing](http://codeception.com/docs/06-UnitTests), and Cest format.
+Codeception supports three test formats. Beside the previously described scenario-based Cept format, Codeception can also execute [PHPUnit test files for unit testing](http://codeception.com/docs/05-UnitTests), and Cest format.
 
 Cest combines scenario-driven test approach with OOP design. In case you want to group a few testing scenarios into one you should consider using Cest format. In the example below we are testing CRUD actions within a single file but with a several test (one per each operation):
 


### PR DESCRIPTION
The link points to 06-UnitTests when it should point to 05-UnitTests.