### PR TITLE
PHP 5.4 build is recommended for PHP 5.5 too

### DIFF
--- a/install.html
+++ b/install.html
@@ -41,7 +41,7 @@ title: Codeception Installation
           <pre><code>wget http://codeception.com/codecept.phar</code></pre>
         </p>
       </div>
-      <p><a href="http://codeception.com/php54/codecept.phar">Download phar for for PHP 5.4 and PHP < 5.5.9</a></p>
+      <p><a href="http://codeception.com/php54/codecept.phar">Download phar for PHP 5.4 and 5.5</a></p>
       <p>For PHP 5.3 <a href="/builds">use the latest version of Codeception 1.8.x</a></p>
 
 

--- a/quickstart.html
+++ b/quickstart.html
@@ -29,7 +29,7 @@ title: Quick Start Codeception
           </div>
 
           <div class="col-sm-6 col-lg-6">
-              <p>If you are using PHP 5.4 or PHP 5.5 < 5.5.9.</p>
+              <p>If you are using PHP 5.4 or 5.5.</p>
               <a class="btn btn-lg btn-success" href="/thanks_php54" target="_blank">Download Codeception</a>
 
               <p class="text-muted">Alternatively download it from console</p>


### PR DESCRIPTION
PHP 5.4 build is recommended for PHP 5.5 too, because the main build will include PHPUnit 5 which requires PHP 5.6