### PR TITLE
Correcting Bootstrap container usage.

### DIFF
--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -12,12 +12,11 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 
     <!-- CSS -->
-    <link href='http://fonts.googleapis.com/css?family=Philosopher&amp;subset=latin' rel='stylesheet' type='text/css'>
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
-
     <link rel="stylesheet" href="/css/codeception.css">
     <link rel="stylesheet" href="/css/contributors.css">
     <link rel="stylesheet" type="text/css" media="screen" href="/css/syntax.css">
+
     <!-- SCRIPTS -->
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js" type="text/javascript"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
@@ -95,10 +94,7 @@
         </div> <!-- /.container -->
     </nav>
 
-    <!-- CONTENT -->
-    <div class="container">
-        {{ content }}
-    </div>
+    {{ content }}
 
     <div id="footer">
         <div class="container">

--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -11,6 +11,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 
+    {% if page.meta %}
+    {{ page.meta }}
+    {% endif %}
+
     <!-- CSS -->
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/codeception.css">

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,40 +1,35 @@
 ---
 layout: bootstrap
 ---
-
-<div class="row">
-  <div class="col-sm-8 col-lg-8">
-    <div class="content page">
-      <div>
-
+<div class="container">
+  <div class="row">
+    <div class="col-sm-8">
+      <div class="content page">
         <div id="page">
           {{ content }}
-        </div>
+        </div> <!-- /#page -->
+      </div> <!-- /.content page -->
+    </div> <!-- /.col -->
+    <div class="col-sm-4">
+     <div id="searchable">
+      <div>
+        <input type="search" class="search" placeholder="live search...">
       </div>
+      <!-- toc.js generated nav... -->
+      <div id="toc" class="nav"></div>
+    </div> <!-- /#searchable -->
 
-    </div>
-  </div>
-  <div class="col-sm-4 col-lg-4">
-
-   <div id="searchable">
-    <input type="search" class="search" placeholder="live search...">
-    <br>
-     <!-- toc.js generated nav... -->
-     <div id="toc" class="nav"></div>
-   </div> <!-- /#searchable -->
-
-   <script type="text/javascript">
-    $(document).ready(function () {
-      $('#toc').toc({
-        'selectors': 'h2,h3,h4',
-        'prefix': 'toc',
-        'container': '#page',
+    <script type="text/javascript">
+      $(document).ready(function () {
+        $('#toc').toc({
+          'selectors': 'h2,h3,h4',
+          'prefix': 'toc',
+          'container': '#page',
         //custom function for anchor name
         'anchorName': function(i, heading, prefix) {
           return $(heading).text().replace(/\s/g, '-').replace(/[^\w-]/g, '');
         },
       });
-
       // List.js
       $('#toc > ul').addClass('list');
       $('#toc ul.list li a').addClass('searchitem');
@@ -43,9 +38,8 @@ layout: bootstrap
       };
       var userList = new List('searchable', options);
       // end List.js
-
-    }); // docrdy
-  </script>
-
-</div>
-</div>
+      }); // docrdy
+    </script>
+  </div> <!-- /.col -->
+</div> <!-- /.row -->
+</div> <!-- /.container -->

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,276 +1,250 @@
 ---
 layout: bootstrap
 ---
-
 <!-- Adding the new Homepage here -->
-<div id="home-hero">
-  <h1><img src="/images/logo.png" alt="Codeception Logo">Codeception</h1>
-  <p class="lead">Modern PHP testing for everyone.</p>
-</div>
-
-<div class="row home">
-  <div class="col-sm-12 col-lg-12">
-  <div class="row home-btns">
-      <div class="col-sm-12 col-md-4 col-md-offset-4 ">
+<div class="fluid-container" id="home-hero">
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12">
+        <h1><img src="/images/logo.png" alt="Codeception Logo">Codeception</h1>
+        <p class="lead">Modern PHP testing for everyone.</p>
+      </div> <!-- /.col -->
+    </div> <!-- /.row -->
+    <div class="row">
+      <div class="col-xs-12 col-md-4 col-md-offset-4">
         <div class="well dark text-center">
           <a class="btn btn-lg btn-warning btn-block" href="/quickstart"><span class="btn-label">Quick Start</span></a><br>
           <p>
             Write and execute a test for an existing app<br>
             <strong>in less then 5 minutes!</strong>
           </p>
-        </div>
-      </div>
-  </div> <!-- /.row -->
-      <div class="row home-btns">
-        <div class="col-xs-12 text-center">
+          </div> <!-- /.well -->
+      </div> <!-- /.col -->
+    </div> <!-- /.row -->
+    <div class="row">
+      <div class="col-xs-12 text-center">
         <aside>
           <a href="https://twitter.com/codeception" class="twitter-follow-button" data-show-count="false"
-             data-lang="en" data-size="large">Follow @Codeception</a>
+          data-lang="en" data-size="large">Follow @Codeception</a>
           <script>!function (d, s, id) {
-              var js, fjs = d.getElementsByTagName(s)[0];
-              if (!d.getElementById(id)) {
-                  js = d.createElement(s);
-                  js.id = id;
-                  js.src = "//platform.twitter.com/widgets.js";
-                  fjs.parentNode.insertBefore(js, fjs);
-              }
+            var js, fjs = d.getElementsByTagName(s)[0];
+            if (!d.getElementById(id)) {
+              js = d.createElement(s);
+              js.id = id;
+              js.src = "//platform.twitter.com/widgets.js";
+              fjs.parentNode.insertBefore(js, fjs);
+            }
           }(document, "script", "twitter-wjs");</script>
         </aside>
-        </div> <!-- /.col -->
-      </div> <!-- /.row -->
+      </div> <!-- /.col -->
+    </div> <!-- /.row -->
+  </div> <!-- /.container -->
+</div> <!-- /.fluid-container -->
 
-    <div class="row">
-      <div class="col-sm-4 col-lg-4">
-        <div class="well">
-          <h4>Acceptance Testing</h4>
-          <p>
-            <b>Selenium WebDriver</b>, PhpBrowser. Data cleanup. Continuous Integration. Remote CodeCoverage.
-          </p>
-        </div>
-      </div>
-      <div class="col-sm-4 col-lg-4">
-        <div class="well">
-          <h4>Functional Testing</h4>
-          <p>
-            <b>Symfony2</b>, <b>Laravel</b>, <b>Yii</b>, <b>Phalcon</b>, <b>Zend Framework</b>, Kohana, Databases, REST,
-            SOAP, CodeCoverage.</p>
-          </div>
-        </div>
+<div class="container">
+      <div class="row">
         <div class="col-sm-4 col-lg-4">
           <div class="well">
-           <h4>API Testing</h4>
-           <p>
-            <b>REST</b>, <b>SOAP</b>, <b>XML-RPC</b> via PHPBrowser or PHP Frameworks.
-          </p>
-          And <strong>Unit Testing</strong> powered by PHPUnit.
+            <h4>Acceptance Testing</h4>
+            <p>
+              <b>Selenium WebDriver</b>, PhpBrowser. Data cleanup. Continuous Integration. Remote CodeCoverage.
+            </p>
+          </div>
+        </div> <!-- /.col -->
+        <div class="col-sm-4 col-lg-4">
+          <div class="well">
+            <h4>Functional Testing</h4>
+            <p>
+              <b>Symfony2</b>, <b>Laravel</b>, <b>Yii</b>, <b>Phalcon</b>, <b>Zend Framework</b>, Kohana, Databases, REST,
+              SOAP, CodeCoverage.</p>
+            </div>
+          </div> <!-- /.col -->
+          <div class="col-sm-4 col-lg-4">
+            <div class="well">
+              <h4>API Testing</h4>
+              <p>
+                <b>REST</b>, <b>SOAP</b>, <b>XML-RPC</b> via PHPBrowser or PHP Frameworks.
+              </p>
+              And <strong>Unit Testing</strong> powered by PHPUnit.
+            </div>
+          </div> <!-- /.col -->
+        </div><!-- /.row -->
+    <div class="row">
+      <div class="col-sm-6 col-lg-6">
+        <p>
+          <!-- AddThis Button END -->
+          <h4>In Action</h4>
+          <img src="/images/demo.gif" style="max-width: 100%;" />
+        </p>
+        <h4>Features</h4>
+        <div class="well page">
+          <ul>
+            <li><strong>Selenium WebDriver</strong> integration</li>
+            <li>Elements matched by <strong>name, CSS, XPath</strong></li>
+            <li><strong>Symfony2, Laravel4, Yii, Phalcon, Zend Framework</strong> integration</li>
+            <li><strong>PageObjects</strong> and StepObjects included</li>
+            <li><strong>BDD</strong>-style readable tests</li>
+            <li>Powered by <strong>PHPUnit</strong></li>
+            <li>API testing: <strong>REST</strong>,<strong>SOAP</strong>,<strong>XML-RPC</strong></li>
+            <li><strong>Facebook</strong> API testing</li>
+            <li><strong>Data Cleanup</strong></li>
+            <li>HTML, XML, TAP, JSON reports</li>
+            <li>CodeCoverage and Remote CodeCoverage</li>
+            <li>Parallel Execution</li>
+          </ul>
         </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-sm-6 col-lg-6">
-<p>
-        <!-- AddThis Button END -->
-
-        <h4>In Action</h4>
-
-        <img src="/images/demo.gif" style="max-width: 100%;" />
-
-</p>
-
-
-
-    <h4>Features</h4>
-    <div class="well page">
-              <ul>
-                <li><strong>Selenium WebDriver</strong> integration</li>
-                <li>Elements matched by <strong>name, CSS, XPath</strong></li>
-                <li><strong>Symfony2, Laravel4, Yii, Phalcon, Zend Framework</strong> integration</li>
-                <li><strong>PageObjects</strong> and StepObjects included</li>
-                <li><strong>BDD</strong>-style readable tests</li>
-                <li>Powered by <strong>PHPUnit</strong></li>
-                <li>API testing: <strong>REST</strong>,<strong>SOAP</strong>,<strong>XML-RPC</strong></li>
-                <li><strong>Facebook</strong> API testing</li>
-                <li><strong>Data Cleanup</strong></li>
-                <li>HTML, XML, TAP, JSON reports</li>
-                <li>CodeCoverage and Remote CodeCoverage</li>
-                <li>Parallel Execution</li>
-              </ul>
-
-    </div>
-
-
-    <div class="well page">
-      <h3>Questions you wanted to ask</h3>
-    <br>
-      <h4>Do I really need this?</h4>
-      <p>If you develop complex web applications with forms, then you <em>need</em> to use a testing framework. A testing framework allows you to test all links, forms, pages, APIs, and anything else in just minutes using automated test scripts.
-      </p>
-    <br>
-      <h4>Why should I use this instead of PHPUnit?</h4>
-      <p>PHPUnit has very limited features for functional testing with
-        <b>Selenium</b> or other backends. Codeception is
-        <b>PHPUnit on steroids</b>. Everything you need for testing is built-in, and 'just works' out of the box. No more pain in configuring Selenium, data cleanup, writing XPaths, or fixtures.
-      </p>
-    <br>
-
-      <h4>It looks just like Behat</h4>
-      <p>Unlike Behat, Codeception tests are written in PHP. They are flexible and easy to write. You can use
-        <b>variables and operators</b>, <b>CSS and XPath</b> locators in your tests. These features allow you to build a solid test automation platform for testing your web application. Codeception tests are simple and readable for your developers, managers, and QA team.
-      </p>
-
-    <br>
-      <h4>We are planning to use Selenium IDE. Why Codeception?</h4>
-      <p>Codeception works great with Selenium. But with Codeception you can write your tests in PHP.
-        The main reason is: <strong>Selenium IDE tests are tightly bound to XPath locators</strong>.
-        If you ever change anything in the layout, tests will fail. Codeception locators are more stable. You can use names, labels, button names and CSS to match elements on page. It's much easier to support the Codeception test then Selenium's. Codeception can clean data between tests, can check database values, and can generate code coverage reports.
-      </p>
-
-    <br>
-      <h4>Is Codeception a tool for testing legacy projects?</h4>
-      <p>Sure, you can use Codeception for black-box testing of your legacy applications. But in the same manner you can start testing modern web application as well. With modules that integrates with <b>all popular PHP frameworks</b> you can start writing functional tests in seconds. Unit tests? Write them as you do in PHPUnit with some enhancement. Codeception keeps your tests in one place, makes them structured and readable.
-      </p>
-    </div>
-  </div>
-
-  <div class="col-sm-6 col-lg-6">
-    <h5>Blog</h5>
+        <div class="well page">
+          <h3>Questions you wanted to ask</h3>
+          <br>
+          <h4>Do I really need this?</h4>
+          <p>If you develop complex web applications with forms, then you <em>need</em> to use a testing framework. A testing framework allows you to test all links, forms, pages, APIs, and anything else in just minutes using automated test scripts.
+          </p>
+          <br>
+          <h4>Why should I use this instead of PHPUnit?</h4>
+          <p>PHPUnit has very limited features for functional testing with
+            <b>Selenium</b> or other backends. Codeception is
+            <b>PHPUnit on steroids</b>. Everything you need for testing is built-in, and 'just works' out of the box. No more pain in configuring Selenium, data cleanup, writing XPaths, or fixtures.
+          </p>
+          <br>
+          <h4>It looks just like Behat</h4>
+          <p>Unlike Behat, Codeception tests are written in PHP. They are flexible and easy to write. You can use
+            <b>variables and operators</b>, <b>CSS and XPath</b> locators in your tests. These features allow you to build a solid test automation platform for testing your web application. Codeception tests are simple and readable for your developers, managers, and QA team.
+          </p>
+          <br>
+          <h4>We are planning to use Selenium IDE. Why Codeception?</h4>
+          <p>Codeception works great with Selenium. But with Codeception you can write your tests in PHP.
+            The main reason is: <strong>Selenium IDE tests are tightly bound to XPath locators</strong>.
+            If you ever change anything in the layout, tests will fail. Codeception locators are more stable. You can use names, labels, button names and CSS to match elements on page. It's much easier to support the Codeception test then Selenium's. Codeception can clean data between tests, can check database values, and can generate code coverage reports.
+          </p>
+          <br>
+          <h4>Is Codeception a tool for testing legacy projects?</h4>
+          <p>Sure, you can use Codeception for black-box testing of your legacy applications. But in the same manner you can start testing modern web application as well. With modules that integrates with <b>all popular PHP frameworks</b> you can start writing functional tests in seconds. Unit tests? Write them as you do in PHPUnit with some enhancement. Codeception keeps your tests in one place, makes them structured and readable.
+          </p>
+        </div>
+      </div> <!-- /col -->
+      <div class="col-sm-6 col-lg-6">
+        <h5>Blog</h5>
         <ul class="list-group">
-        {% for post in site.posts limit: 3 %}
-        <li class="list-group-item">
-          <div class="pull-right">{{ post.date | date: "%B %d, %Y" }}</div>
-          <span>
-            <a href="{{ post.url }}">{{ post.title }}</a>
-          </span>
-        </li>
-        {% endfor %}
+          {% for post in site.posts limit: 3 %}
+          <li class="list-group-item">
+            <div class="pull-right">{{ post.date | date: "%B %d, %Y" }}</div>
+            <span>
+              <a href="{{ post.url }}">{{ post.title }}</a>
+            </span>
+          </li>
+          {% endfor %}
         </ul>
-<hr>
+        <hr>
         <h2>Examples...</h2>
         <h3>Acceptance Test</h3>
         <span class="badge">PhpBrowser</span>
         <span class="badge">Db</span>
-        <p>
+<p>
 {% highlight php %}
 <?php
-$I = new AcceptanceTester($scenario);
-$I->wantTo('create wiki page');
-$I->amOnPage('/');
-$I->click('Pages');
-$I->click('New');
-$I->see('New Page');
-$I->fillField('title', 'Hobbit');
-$I->fillField('body', 'By Peter Jackson');
-$I->click('Save');
-$I->see('page created'); // notice generated
-$I->see('Hobbit','h1'); // head of page of is our title
-$I->seeInCurrentUrl('pages/hobbit');
-$I->seeInDatabase('pages', array('title' => 'Hobbit'));
+  $I = new AcceptanceTester($scenario);
+  $I->wantTo('create wiki page');
+  $I->amOnPage('/');
+  $I->click('Pages');
+  $I->click('New');
+  $I->see('New Page');
+  $I->fillField('title', 'Hobbit');
+  $I->fillField('body', 'By Peter Jackson');
+  $I->click('Save');
+  $I->see('page created'); // notice generated
+  $I->see('Hobbit','h1'); // head of page of is our title
+  $I->seeInCurrentUrl('pages/hobbit');
+  $I->seeInDatabase('pages', array('title' => 'Hobbit'));
 ?>
 {% endhighlight %}
-        </p>
+</p>
         <p>This test can be executed inside Mozilla Firefox using Selenium Webdriver,
           or any browser. You can also execute this test without any browser
           by using a PHP browser emulator based on CURL.
         </p>
-          <p>
+        <p>
           <a class="btn btn-default" href="/docs/03-AcceptanceTests"><span class="btn-label">Read more about Acceptance Tests →</span></a>
-          </p>
-
-          <p>
-            This test can be also executed as a functional test in one of the popular PHP frameworks.
-            Codeception has modules that support <strong>Symfony2</strong>, Zend Framework and Kohana.
-          </p>
-
-          <p>
+        </p>
+        <p>
+          This test can be also executed as a functional test in one of the popular PHP frameworks.
+          Codeception has modules that support <strong>Symfony2</strong>, Zend Framework and Kohana.
+        </p>
+        <p>
           <a class="btn btn-default" href="/docs/04-FunctionalTests"><span class="btn-label">Read more about Functional Tests →</span></a>
-          </p>
-
-            <hr>
-
-<h3>API Test</h3>
-<span class="badge">PhpBrowser</span>
-<span class="badge">REST</span>
-
-<p>
+        </p>
+        <hr>
+        <h3>API Test</h3>
+        <span class="badge">PhpBrowser</span>
+        <span class="badge">REST</span>
+        <p>
 {% highlight php %}
 <?php
-$I = new ApiTester($scenario);
-$I->wantTo('create a new user by API');
-$I->amHttpAuthenticated('davert','123456');
-$I->haveHttpHeader('Content-Type','application/x-www-form-urlencoded');
-$I->sendPOST('/users', array('name' => 'davert' ));
-$I->seeResponseCodeIs(200);
-$I->seeResponseIsJson();
-$I->seeResponseContainsJson(array('result' => 'ok'));
+  $I = new ApiTester($scenario);
+  $I->wantTo('create a new user by API');
+  $I->amHttpAuthenticated('davert','123456');
+  $I->haveHttpHeader('Content-Type','application/x-www-form-urlencoded');
+  $I->sendPOST('/users', array('name' => 'davert' ));
+  $I->seeResponseCodeIs(200);
+  $I->seeResponseIsJson();
+  $I->seeResponseContainsJson(array('result' => 'ok'));
 ?>
 {% endhighlight %}
-</p>
-
-<p>
-This test can be executed inside PhpBrowser or as a functional test of one of the most popular PHP frameworks.
-  </p>
-
-  <p>
-        <a class="btn btn-default" href="/docs/10-WebServices"><span class="btn-label">Read more about API Tests →</span></a>
-  </p>
-<hr>
-
-<h3>Unit Test</h3>
-<span class="badge">Unit</span>
-<span class="badge">Db</span>
-<p>
-  {% highlight php %}
-  <?php
+        </p>
+        <p>
+          This test can be executed inside PhpBrowser or as a functional test of one of the most popular PHP frameworks.
+        </p>
+        <p>
+          <a class="btn btn-default" href="/docs/10-WebServices"><span class="btn-label">Read more about API Tests →</span></a>
+        </p>
+        <hr>
+        <h3>Unit Test</h3>
+        <span class="badge">Unit</span>
+        <span class="badge">Db</span>
+        <p>
+{% highlight php %}
+<?php
   use \Codeception\Util\Stub;
   class UserTest extends \Codeception\TestCase\Test
   {
-      public function testUserSave() {
-          $user = Stub::make('User');
-          $user->setName('davert');
-          $this->assertEquals('davert', $user->getName());
-          $user->save();
-          $this->tester->seeInDatabase('users', array('name' => 'davert'));
-      }
+    public function testUserSave() {
+      $user = Stub::make('User');
+      $user->setName('davert');
+      $this->assertEquals('davert', $user->getName());
+      $user->save();
+      $this->tester->seeInDatabase('users', array('name' => 'davert'));
+    }
   }
-  ?>
-  {% endhighlight %}
-  </p>
-<p>
-  PHPUnit test format with some useful helpers.
-  In this test we check that value was saved to database with one simple command 'seeInDatabase'.
-</p>
-<a class="btn btn-default" href="/docs/05-UnitTests"><span class="btn-label">Read more about Unit Tests →</span></a>
-
-<hr>
-
-<h2>AspectMock</h2>
-<p>
-  A side-project of Codeception for unit testing any PHP code.
-  <a href="https://github.com/Codeception/AspectMock">AspectMock</a>
-  most powerful mocking framework that can stub and mock practically anything. Even static methods,
-  can be tested now. Use it for legacy or untestable code.
-</p>
-
-{% highlight php %}
-<?php;
-// mocking static method calls
-$this->assertEquals('users', User::tableName());
-test::double('User', ['tableName' => 'fake_users']);
-$this->assertEquals('fake_users', User::tableName());
-
-// mocking class method calls
-test::double('User', ['getEmail' => 'davert@mail.ua']);
-$user = new User;
-$this->assertEquals('davert@mail.ua', $user->getEmail());
 ?>
 {% endhighlight %}
-
-<a class="btn btn-primary" href="https://github.com/Codeception/AspectMock">
-  Install AspectMock →
-</a>
-
-</div>
-</div>
+    </p>
+    <p>
+      PHPUnit test format with some useful helpers.
+      In this test we check that value was saved to database with one simple command 'seeInDatabase'.
+    </p>
+    <a class="btn btn-default" href="/docs/05-UnitTests"><span class="btn-label">Read more about Unit Tests →</span></a>
+    <hr>
+    <h2>AspectMock</h2>
+    <p>
+      A side-project of Codeception for unit testing any PHP code.
+      <a href="https://github.com/Codeception/AspectMock">AspectMock</a>
+      most powerful mocking framework that can stub and mock practically anything. Even static methods,
+      can be tested now. Use it for legacy or untestable code.
+    </p>
+{% highlight php %}
+<?php;
+  // mocking static method calls
+  $this->assertEquals('users', User::tableName());
+  test::double('User', ['tableName' => 'fake_users']);
+  $this->assertEquals('fake_users', User::tableName());
+  // mocking class method calls
+  test::double('User', ['getEmail' => 'davert@mail.ua']);
+  $user = new User;
+  $this->assertEquals('davert@mail.ua', $user->getEmail());
+?>
+{% endhighlight %}
+    <a class="btn btn-primary" href="https://github.com/Codeception/AspectMock">
+      Install AspectMock →
+    </a>
+  </div> <!-- /col -->
+</div> <!-- /row -->
+</div> <!-- /.container -->

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,53 +1,48 @@
 ---
 layout: bootstrap
 ---
-<div class="row">
-  <div class="col-sm-8 col-lg-8">
-    <div class="content page" id="page"> 
-
-      <div>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-8">
+      <div class="content page" id="page">
         {{ content }}
-      </div>  
-    </div>
-  </div>
-  <div class="col-sm-4 col-lg-4">
+      </div> <!-- /.content page -->
+    </div> <!-- /.col -->
+    <div class="col-sm-4 col-lg-4">
+      <div class="well text-center">
+        <a class="btn btn-lg btn-warning btn-block" href="/quickstart"><span class="btn-label">Quick Start</span></a><br>
+        <p>
+          Write and execute a test for an existing app<br>
+          <strong>in less then 5 minutes!</strong>
+        </p>
+      </div> <!-- /.well -->
+      <div class="links">
+        <a href="https://github.com/codeception/codeception">
+          <img src="/images/github.png"> GitHub Repository
+        </a>
+      </div>
+      <div id="toc"></div>
+      <div>
+        <a href="http://codeception.com/thanks.html">
+          <img src="https://poser.pugx.org/Codeception/Codeception/version.png" alt="Latest stable version">
+        </a>
+      </div>
+      <div>
+        <img src="https://camo.githubusercontent.com/ba3ef343659e0ec242700c28c571dd89c6fd54d8/68747470733a2f2f706f7365722e707567782e6f72672f636f646563657074696f6e2f636f646563657074696f6e2f646f776e6c6f6164732e706e67" alt="Total Downloads" data-canonical-src="https://poser.pugx.org/codeception/codeception/downloads.png" style="max-width:100%;">
+      </div>
+    </div> <!-- /.col -->
+  </div> <!-- /.row -->
+</div> <!-- /.container -->
 
-    <div class="well">
-      <a class="btn btn-lg btn-warning btn-block" href="/quickstart">Quick Start →</a>
-      <p><br/>Write and execute a test for an existing app
-        <b>in less then a 5 mins!</b>&nbsp;No additional tools required.&nbsp;
-      </p>
-    </div>
-    <p>
-          </p>
-      <div class="links">               <a href="https://github.com/codeception/codeception">
-                <img src="/images/github.png"> GitHub Repository
-              </a>
-</div>
-
-<div id="toc"></div>
-
-          <div>
-      <a href="http://codeception.com/thanks.html">
-      <img src="https://poser.pugx.org/Codeception/Codeception/version.png" alt="Latest stable version">
-      </a>
-    </div>
-    <div>
-      <img src="https://camo.githubusercontent.com/ba3ef343659e0ec242700c28c571dd89c6fd54d8/68747470733a2f2f706f7365722e707567782e6f72672f636f646563657074696f6e2f636f646563657074696f6e2f646f776e6c6f6164732e706e67" alt="Total Downloads" data-canonical-src="https://poser.pugx.org/codeception/codeception/downloads.png" style="max-width:100%;">
-    </div>
-    <p></p>
-  </div>
-</div>
-
-    <script type="text/javascript">
-    $(document).ready(function () {
-      $('#toc').toc({
-        'selectors': 'h2',
-        'prefix': 'toc',
-        'container': '#page',
+<script type="text/javascript">
+  $(document).ready(function () {
+    $('#toc').toc({
+      'selectors': 'h2',
+      'prefix': 'toc',
+      'container': '#page',
     'anchorName': function(i, heading, prefix) { //custom function for anchor name
       return $(heading).text().replace(/\s/g, '-').replace(/[^\w-]/g, '');
-    },    
+    },
   });
-    });
-    </script>
+  }); // docrdy
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,23 +1,18 @@
 ---
 layout: page
 ---
-
-
 <h1>{{ page.title }}</h1>
-
-<p>
-<div class="badge">Published on {{ page.date | date: "%B %d, %Y" }}</div>
+<p class="lead">
+  Published on {{ page.date | date: "%B %d, %Y" }}
 </p>
-
 {{ content }}
-
 <div class="alert alert-info">
+  <a href="http://www.reddit.com/submit" onclick="window.location = 'http://www.reddit.com/submit?url=' + encodeURIComponent(window.location); return false" style="float: right"><img src="http://www.reddit.com/static/spreddit7.gif" alt="submit to reddit" border="0" /></a>
+  <!-- Розмістіть цей тег там, де необхідно розмістити кнопку +1 -->
+  <g:plusone size="tall" annotation="inline"></g:plusone>
+  <a href="https://twitter.com/share" class="twitter-share-button" data-via="codeception">Tweet</a>
+  </div>  <!-- /.alert -->
 
-<a href="http://www.reddit.com/submit" onclick="window.location = 'http://www.reddit.com/submit?url=' + encodeURIComponent(window.location); return false" style="float: right"><img src="http://www.reddit.com/static/spreddit7.gif" alt="submit to reddit" border="0" /></a>
-
-<!-- Розмістіть цей тег там, де необхідно розмістити кнопку +1 -->
-<g:plusone size="tall" annotation="inline"></g:plusone>
-<a href="https://twitter.com/share" class="twitter-share-button" data-via="codeception">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 
 <!-- Розмістіть цю команду відображення в потрібному місці -->
@@ -27,7 +22,5 @@ layout: page
     po.src = 'https://apis.google.com/js/plusone.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
   })();
-</script>	
-</div>
-
+</script>
 {% include comment.html %}

--- a/css/codeception.css
+++ b/css/codeception.css
@@ -1,5 +1,9 @@
 @import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css);
 
+.navbar {
+	margin-bottom: 0;
+}
+
 .main-features {
   margin-top: 10px;
 }
@@ -46,28 +50,6 @@ body h1, body h2, body h3, body h3 {
 
 h1, h2, h3, h4, h5, h6 {
 	font-weight: bold;
-}
-
-body #home-hero h1 {
-	color: #fff;
-	font-size: 56px;
-	font-weight: bold;
-	padding-top:35px;
-	text-shadow: #000 1px 2px 5px;
-}
-
-#home-hero img{
-	position:relative;
-	top:-7px;
-}
-
-#home-hero p.lead {
-	color:#fff;
-}
-
-.hero-unit p.lead {
-	font-weight: bold;
-	font-style: italic;
 }
 
 #page h4 {
@@ -204,18 +186,18 @@ ul.navbar-nav {
 	margin: 0 -15px;
 }
 
-.row.home{
-	padding-top:225px;
-}
+// .row.home{
+// 	padding-top:225px;
+// }
 
-.row.home.no-padding-top{
-	padding-top:0px;
-}
+// .row.home.no-padding-top{
+// 	padding-top:0px;
+// }
 
-.row.home-btns{
-	margin-top:40px;
-	margin-bottom:40px;
-}
+// .row.home-btns{
+// 	margin-top:40px;
+// 	margin-bottom:40px;
+// }
 
 .well.dark{
 	background:#042943;
@@ -231,18 +213,32 @@ ul.navbar-nav {
 	color:#eee;
 }
 
-#home-hero{
-	width:100%;
+#home-hero {
 	height:600px;
-	left:0px;
-	top:50px; /* space needed for navbar */
-	position:absolute;
 	background:#042943 no-repeat center center;
 	background-image: url(../images/home-bg.jpg);
 	background-size:cover;
-	display:block;
 	text-align:center;
 	padding-top:80px;
+}
+
+#home-hero h1 {
+	color: #fff;
+	font-size: 56px;
+	font-weight: bold;
+	padding-top:35px;
+	text-shadow: #000 1px 2px 5px;
+}
+
+#home-hero img {
+	position:relative;
+	top: -8px;
+}
+
+#home-hero p.lead {
+	color:#fff;
+	font-weight: bold;
+	font-style: italic;
 }
 
 @media screen and (max-width : 1260px) {
@@ -253,13 +249,6 @@ ul.navbar-nav {
 
 
 @media screen and (max-width : 992px) {
-	body #home-hero h1{
-		padding-top:75px;
-	}
-
-	#home-hero{
-		height:320px;
-	}
 
 	.well.dark{
 		background:#fff;
@@ -284,12 +273,13 @@ ul.navbar-nav {
 
 @media screen and (max-width : 767px) {
 
-	.menu li {
-		clear: both;
+	#home-hero {
+		height: 500px;
+		padding-top: 0;
 	}
 
-	body #home-hero h1{
-		padding-top:0px;
+	.menu li {
+		clear: both;
 	}
 }
 
@@ -301,7 +291,10 @@ ul.navbar-nav {
 		overflow: visible!important;
 	}
 }
-#searchable > .search {
+#searchable {
+	margin-top: 20px;
+}
+#searchable .search {
 	width: 100%;
 	height: 45px;
 	color: #888;
@@ -313,12 +306,12 @@ ul.navbar-nav {
 	outline: none;
 }
 
-#searchable::before {
+#searchable::after {
 	font-family: "FontAwesome";
 	content: "\f002";
 	color: #ccc;
 	position: absolute;
-	top: 13px;
+	top: 34px;
 	right: 40px;
 }
 

--- a/css/codeception.css
+++ b/css/codeception.css
@@ -1,3 +1,5 @@
+@import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css);
+
 .main-features {
   margin-top: 10px;
 }
@@ -302,11 +304,22 @@ ul.navbar-nav {
 #searchable > .search {
 	width: 100%;
 	height: 45px;
-	color: #333;
+	color: #888;
 	text-indent: 16px;
 	border-radius: 24px;
 	border: 1px solid #ddd;
-	box-shadow: inset 0 1px 1px hsla(0, 0%, 0%, 0.075);
+	box-shadow: inset 0 1px 1px #ccc;
 	transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 	outline: none;
 }
+
+#searchable::before {
+	font-family: "FontAwesome";
+	content: "\f002";
+	color: #ccc;
+	position: absolute;
+	top: 13px;
+	right: 40px;
+}
+
+

--- a/css/codeception.css
+++ b/css/codeception.css
@@ -315,4 +315,8 @@ ul.navbar-nav {
 	right: 40px;
 }
 
+.fill-thanks {
+	padding-top: 200px;
+	padding-bottom: 200px;
+}
 

--- a/install.html
+++ b/install.html
@@ -2,135 +2,103 @@
 layout: bootstrap
 title: Codeception Installation
 ---
-
-
-<div class="page-header">
-  <div class="pull-right well">
-    <h4>Requirements</h4>
-    <strong>
-      <div>PHP 5.3</div>
-      <div>CURL enabled</div>
-    </strong>
+<div class="container">
+  <div class="page-header">
+    <div class="pull-right well">
+      <h4>Requirements</h4>
+      <strong>
+        <div>PHP 5.3</div>
+        <div>CURL enabled</div>
+      </strong>
+    </div>
+    <h1>Installation</h1>
   </div>
-
-  <h1>Installation</h1>
-</div>
-<div class="row">
-  <div class="col-sm-8 col-lg-8">
-    <div class="page-header">
-      <div class="pull-right">
-        &nbsp;
-        <a class="btn btn-lg btn-warning" href="/quickstart">QuickStart Guide &rarr;</a> 
+  <div class="row">
+    <div class="col-sm-8 col-lg-8">
+      <div class="page-header">
+        <div class="pull-right">
+          &nbsp;
+          <a class="btn btn-lg btn-warning" href="/quickstart">QuickStart Guide &rarr;</a>
+        </div>
+        <h4>Follow QuickStart Guide to Install and execute your first test in 6 easy
+          steps.
+        </h4>
       </div>
-
-
-      <h4>Follow QuickStart Guide to Install and execute your first test in 6 easy
-        steps.      
-      </h4>
     </div>
   </div>
-</div>
-<div class="row">
-  <div class="col-sm-6 col-lg-6">
-    <div class="well">
-      <h3>Phar</h3>
-      <a class="btn btn-lg btn-success" href="/thanks"><span class="btn-label">Download Codeception</span></a>
-      <p>Alternatively download it from console</p>
+  <div class="row">
+    <div class="col-sm-6 col-lg-6">
+      <div class="well">
+        <h3>Phar</h3>
+        <a class="btn btn-lg btn-success" href="/thanks"><span class="btn-label">Download Codeception</span></a>
+        <p>Alternatively download it from console</p>
+        <div>
+          <p>
+            <pre><code>wget http://codeception.com/codecept.phar</code></pre>
+          </p>
+        </div>
+        <p><a href="http://codeception.com/php54/codecept.phar">Download phar for for PHP 5.4 and PHP < 5.5.9</a></p>
+        <p>For PHP 5.3 <a href="/builds">use the latest version of Codeception 1.8.x</a></p>
+        <p>Prepare tests directory and configs</p>
+        <div>
+          <p>
+            <pre><code>php codecept.phar bootstrap</code></pre>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6 col-lg-6">
       <div>
+        <h3>Composer</h3>
+        <p>Install a <a href="http://getcomposer.org">Composer</a> to your project's root</p>
+        <p>Run</p>
         <p>
-          <pre><code>wget http://codeception.com/codecept.phar</code></pre>
+          <pre><code>php composer.phar require "codeception/codeception:*"</code></pre>
+        </p>
+        <p>From now on Codeception (with installed PHPUnit) can be run as:</p>
+        <p>
+          <pre><code>php vendor/bin/codecept</code></pre>
+        </p>
+        <p>Initialize your testing environment with</p>
+        <p>
+          <pre><code>php vendor/bin/codecept bootstrap</code></pre>
+        </p>
+        <h3>Minimal Codeception</h3>
+        <p>Currently Codeception installs Webdriver and Guzzle libraries as dependencies. If you don't plan to do acceptance testing, you can get minimal installation of Codeception by requiring `codeception/base`</p>
+        <p>
+          <pre><code>php composer.phar require "codeception/base:*" --dev</code></pre>
         </p>
       </div>
-      <p><a href="http://codeception.com/php54/codecept.phar">Download phar for for PHP 5.4 and PHP < 5.5.9</a></p>
-      <p>For PHP 5.3 <a href="/builds">use the latest version of Codeception 1.8.x</a></p>
-
-
-      <p>Prepare tests directory and configs</p>
-      <div>
-        <p>
-          <pre><code>php codecept.phar bootstrap</code></pre>
-        </p>
-      </div>
     </div>
   </div>
-  <div class="col-sm-6 col-lg-6">
-    <div>
-      <h3>Composer</h3>
-
-<p>Install a <a href="http://getcomposer.org">Composer</a> to your project's root</p>
-
-<p>Run</p>
-
-<p>
-<pre><code>php composer.phar require "codeception/codeception:*"</code></pre>
-</p>
-
-
-<p>From now on Codeception (with installed PHPUnit) can be run as:</p>
-
-<p>
-<pre><code>php vendor/bin/codecept</code></pre>
-</p>
-
-<p>Initialize your testing environment with</p>
-
-<p>
-<pre><code>php vendor/bin/codecept bootstrap</code></pre>
-</p>
-
-<h3>Minimal Codeception</h3>
-
-<p>Currently Codeception installs Webdriver and Guzzle libraries as dependencies. If you don't plan to do acceptance testing, you can get minimal installation of Codeception by requiring `codeception/base`</p>
-
-<p>
-<pre><code>php composer.phar require "codeception/base:*" --dev</code></pre>
-</p>
-
-
-    </div>
-  </div>
-  </div>
-
-<hr>
-
+  <hr>
   <div class="row page">
-  <h3>Git</h3>
-
-  <p>Alternative installation method for bugfixing, contributions and hacking</p>
-  <p>
-  Clone from GitHub:
-  </p>
-<pre><code>git clone git@github.com:Codeception/Codeception.git</code></pre>
-
-<p>
-Install dependencies with Composer
-</p>
-
-<p>
-<pre><code>cd Codeception
-curl -s http://getcomposer.org/installer | php
-php composer.phar install</code></pre>
-</p>
-
-<p>
-  Execute bootstrap, specifying path to your directory.
-</p>
-
-<pre><code>php codecept bootstrap /path/to/my/project</code></pre>
-
-<p>
-  To <strong>run tests</strong> use <code>-c</code> option for specifing path.  
-</p>
-
-<pre><code>php codecept run -c /path/to/my/project</code></pre>
-
-<p>If you want to build phar package you need to install <a href="http://robo.li">Robo Task Runner</a> and execute
-<code>robo build:phar</code>
-
-</p>
-
-
-  </p>
-  <p>Don't forget to send Pull Requests!</p>
+    <h3>Git</h3>
+    <p>Alternative installation method for bugfixing, contributions and hacking</p>
+    <p>
+      Clone from GitHub:
+    </p>
+    <pre><code>git clone git@github.com:Codeception/Codeception.git</code></pre>
+    <p>
+      Install dependencies with Composer
+    </p>
+    <p>
+      <pre><code>cd Codeception
+        curl -s http://getcomposer.org/installer | php
+        php composer.phar install</code></pre>
+      </p>
+      <p>
+        Execute bootstrap, specifying path to your directory.
+      </p>
+      <pre><code>php codecept bootstrap /path/to/my/project</code></pre>
+      <p>
+        To <strong>run tests</strong> use <code>-c</code> option for specifing path.
+      </p>
+      <pre><code>php codecept run -c /path/to/my/project</code></pre>
+      <p>If you want to build phar package you need to install <a href="http://robo.li">Robo Task Runner</a> and execute
+        <code>robo build:phar</code>
+      </p>
+    </p>
+    <p>Don't forget to send Pull Requests!</p>
   </div>
-
+</div> <!-- /.container -->

--- a/install.html
+++ b/install.html
@@ -55,7 +55,6 @@ title: Codeception Installation
         <p>
           <pre><code>php composer.phar require "codeception/codeception:*"</code></pre>
         </p>
-<<<<<<< HEAD
         <p>From now on Codeception (with installed PHPUnit) can be run as:</p>
         <p>
           <pre><code>php vendor/bin/codecept</code></pre>
@@ -66,7 +65,6 @@ title: Codeception Installation
         </p>
         <h3>Minimal Codeception</h3>
         <p>Currently Codeception installs Webdriver and Guzzle libraries as dependencies. If you don't plan to do acceptance testing, you can get minimal installation of Codeception by requiring `codeception/base`</p>
-=======
       </div>
       <p><a href="http://codeception.com/php54/codecept.phar">Download phar for PHP 5.4 and 5.5</a></p>
       <p>For PHP 5.3 <a href="/builds">use the latest version of Codeception 1.8.x</a></p>
@@ -74,7 +72,6 @@ title: Codeception Installation
 
       <p>Prepare tests directory and configs</p>
       <div>
->>>>>>> Codeception/master
         <p>
           <pre><code>php composer.phar require "codeception/base:*" --dev</code></pre>
         </p>

--- a/quickstart.html
+++ b/quickstart.html
@@ -2,31 +2,28 @@
 layout: bootstrap
 title: Quick Start Codeception
 ---
+<div class="container">
 
-<div class="row">
-  <div class="col-xs-12 col-md-9">
-    <h1>Codeception Quickstart Guide</h1>
-    <p class="lead">Codeception PHP Testing Framework is designed to work just out of the box.
-      This means its installation requires minimal steps and no external dependencies
-      preinstalled (except PHP, of course). Only one configuration step should
-      be taken and you are ready to test your web application from an eye of
-      actual user.</p>
+  <div class="row">
+    <div class="col-xs-12 col-md-9">
+      <h1>Codeception Quickstart Guide</h1>
+      <p class="lead">Codeception PHP Testing Framework is designed to work just out of the box. This means its installation requires minimal steps and no external dependencies preinstalled (except PHP, of course). Only one configuration step should be taken and you are ready to test your web application from an eye of actual user.</p>
       <p>
         <strong class="text-info text-uppercase">Requirements: PHP5.3, CURL enabled</strong>
       </p>
-  </div> <!-- /.col -->
-</div> <!-- /.row -->
+    </div> <!-- /.col -->
+  </div> <!-- /.row -->
 
 <div class="row">
 <div class="col-xs-12 col-md-9">
-    <div class="panel panel-info">
-      <div class="panel-heading"><h4 class="panel-title">1. Download</h4></div>
-      <div class="panel-body">
-          <div class="">
-            <p class="lead">Install via Composer</p>
-            <pre>$ composer require "codeception/codeception"  <span class="text-muted">// ./vendor/bin/codecept</span></pre>
-            <p><code class="text-muted">$ alias codecept='./vendor/bin/codecept'</code></p>
-          </div>
+<div class="panel panel-info">
+<div class="panel-heading"><h4 class="panel-title">1. Download</h4></div>
+<div class="panel-body">
+<div class="">
+<p class="lead">Install via Composer</p>
+<pre>$ composer require "codeception/codeception"  <span class="text-muted">// ./vendor/bin/codecept</span></pre>
+<p><code class="text-muted">$ alias codecept='./vendor/bin/codecept'</code></p>
+</div>
 <hr>
 
 <p class="lead">Install PHAR locally</p>
@@ -37,56 +34,54 @@ title: Quick Start Codeception
 <!-- phar php54 -->
 <pre>$ wget http://codeception.com/php54/codecept.phar <span class="text-muted">// PHP 5.4 >= 5.5.9</span><a href="/thanks_php54" style="float:right" target="_blank">download <span class="glyphicon glyphicon-download"></span></a></pre>
 <p><code class="text-muted">$ alias codecept='codecept.phar'</code></p>
-    <div>
-    </div>
 
 <hr>
-          <p class="lead">Install PHAR globally</p>
-          <pre>sudo curl -LsS http://codeception.com/codecept.phar -o /usr/local/bin/codecept</pre>
-          <pre>sudo chmod a+x /usr/local/bin/codecept</pre>
-          <p><code class="text-muted">$ codecept</code></p>
+<p class="lead">Install PHAR globally</p>
+<pre>sudo curl -LsS http://codeception.com/codecept.phar -o /usr/local/bin/codecept</pre>
+<pre>sudo chmod a+x /usr/local/bin/codecept</pre>
+<p><code class="text-muted">$ codecept</code></p>
 
-          <!-- <p>Use <code>codecept</code> instead of codecept.phar in this case.</p> -->
-        </div> <!-- /.panel-body -->
-      </div> <!-- /.panel -->
-
-      <div class="panel panel-info">
-        <div class="panel-heading"><h4 class="panel-title">2. Install</h4></div>
-        <div class="panel-body">
-          <p>Open console directory where you saved codecept.phar file and execute:</p>
-          <div>
-            <p>
-              <pre>php codecept.phar bootstrap</pre>
-            </p>
-          </div>
-          <p class="text-muted">This creates
-            <b>codeception.yml</b> file and <b>tests</b> directory.</p>
-              </div> <!-- /.panel-body -->
-            </div> <!-- /.panel -->
-
-        <div class="panel panel-info">
-          <div class="panel-heading"><h4 class="panel-title">3. Create Test</h4></div>
-          <div class="panel-body">
-            <p>Generate your first acceptance test. Acceptance tests emulate behavior
-              of a real user visiting your site.</p>
-              <div>
-                <p>
-                  <pre>php codecept.phar generate:cept acceptance Welcome</pre>
-                </p>
-              </div>
-              <p class="text-muted">Codeception scenario tests are called Cepts.</p>
-                </div> <!-- /.panel-body -->
-              </div> <!-- /.panel -->
+<!-- <p>Use <code>codecept</code> instead of codecept.phar in this case.</p> -->
+</div> <!-- /.panel-body -->
+</div> <!-- /.panel -->
 
 <div class="panel panel-info">
-  <div class="panel-heading">
-    <h4 class="panel-title">4. Write Basic Test</h4>
-  </div>
-  <div class="panel-body">
-    <p>It's now time to write your first test. Edit the file we've just created
-      <b>tests/acceptance/WelcomeCept.php</b>
-    </p>
-    <div>
+<div class="panel-heading"><h4 class="panel-title">2. Install</h4></div>
+<div class="panel-body">
+<p>Open console directory where you saved codecept.phar file and execute:</p>
+<div>
+<p>
+<pre>$ codecept bootstrap</pre>
+</p>
+</div>
+<p class="text-muted">This creates
+<b>codeception.yml</b> file and <b>tests</b> directory.</p>
+</div> <!-- /.panel-body -->
+</div> <!-- /.panel -->
+
+<div class="panel panel-info">
+<div class="panel-heading"><h4 class="panel-title">3. Create Test</h4></div>
+<div class="panel-body">
+<p>Generate your first acceptance test. Acceptance tests emulate behavior
+of a real user visiting your site.</p>
+<div>
+<p>
+<pre>$ codecept generate:cept acceptance Welcome</pre>
+</p>
+</div>
+<p class="text-muted">Codeception scenario tests are called Cepts.</p>
+</div> <!-- /.panel-body -->
+</div> <!-- /.panel -->
+
+<div class="panel panel-info">
+<div class="panel-heading">
+<h4 class="panel-title">4. Write Basic Test</h4>
+</div>
+<div class="panel-body">
+<p>It's now time to write your first test. Edit the file we've just created
+<b>tests/acceptance/WelcomeCept.php</b>
+</p>
+<div>
 {% highlight php %}
 <?php
   $I = new AcceptanceTester($scenario);
@@ -95,76 +90,79 @@ title: Quick Start Codeception
   $I->see('Home');
 ?>
 {% endhighlight %}
-    </div>
-    <p class="text-muted">It will check that your frontpage contains the word <b>Home</b> in it.</p>
-      </div> <!-- /.panel-body -->
-    </div> <!-- /.panel -->
+</div>
+<p class="text-muted">It will check that your frontpage contains the word <b>Home</b> in it.</p>
+</div> <!-- /.panel-body -->
+</div> <!-- /.panel -->
 
 <div class="panel panel-info">
-<div class="panel-heading"><h4 class="panel-title">5. Configure Acceptance Tests</h4></div>
+<div class="panel-heading"><h4 class="panel-title">
+  5. Configure Acceptance Tests</h4>
+</div>
 <div class="panel-body">
-  <p>Please make sure your local
-    <b>dev server</b>is running. &nbsp;Put application URL into:&nbsp;
-    <b>tests/acceptance.suite.yml</b>&nbsp;</p>
-    <div>
+<p>Please make sure your local
+<b>dev server</b>is running. &nbsp;Put application URL into:&nbsp;
+<b>tests/acceptance.suite.yml</b>&nbsp;</p>
+<div>
 <pre>
-  class_name: AcceptanceTester
-  modules:
-  enabled:
-    - PhpBrowser:
-  url: {YOUR APP'S URL}
-    - \Helper\Acceptance
+class_name: AcceptanceTester
+modules:
+enabled:
+  - PhpBrowser:
+url: {YOUR APP'S URL}
+  - \Helper\Acceptance
 </pre>
-    </div>
-      </div> <!-- /.panel-body -->
-    </div> <!-- /.panel -->
+</div>
+</div> <!-- /.panel-body -->
+</div> <!-- /.panel -->
 
 <div class="panel panel-info">
-  <div class="panel-heading"><h4 class="panel-title">6. Run!</h4></div>
-  <div class="panel-body">
-    <p>Codeception are executed with 'run' command</p>
-    <div>
-      <p>
-        <pre>php codecept.phar run</pre>
-      </p>
-    </div>
-    <p class="text-muted">This will execute our Welcome test with
-      <b>PhpBrowser</b>. It's PHP script that can check HTML page contents, click
-      links, fill forms, and submit POST and GET requests. For more complex tests
-      that require a browser use Selenium with
-      <b>WebDriver</b> module.</p>
-        </div> <!-- /.panel-body -->
-      </div> <!-- /.panel -->
+<div class="panel-heading"><h4 class="panel-title">6. Run!</h4></div>
+<div class="panel-body">
+<p>Codeception are executed with 'run' command</p>
+<div>
+<p>
+<pre>$ codecept run</pre>
+</p>
+</div>
+<p class="text-muted">This will execute our Welcome test with
+<b>PhpBrowser</b>. It's PHP script that can check HTML page contents, click
+links, fill forms, and submit POST and GET requests. For more complex tests
+that require a browser use Selenium with
+<b>WebDriver</b> module.</p>
+</div> <!-- /.panel-body -->
+</div> <!-- /.panel -->
 </div> <!-- /.col -->
 </div> <!-- /.row -->
 
-<div class="container">
-  <div class="row">
-<div class="col-sm-8 col-lg-8">
+<div class="row">
+<div class="col-sm-9 col-lg-9">
 <div class="panel panel-success">
 <div class="panel-heading">If you did everything right and your app has "Home" text on frontpage you
-  will see this in output</div>
-  <div class="panel-body">
+will see this in output</div>
+<div class="panel-body">
 <pre>Suite acceptance started
 Trying to <b>ensure that frontpage works</b> (WelcomeCept.php) - Ok
 Suite functional started
 Suite unit started
 
 Time: 1 second, Memory: 21.00Mb
-  <b>OK (1 test, 1 assertions)</b></pre>
-  </div> <!-- /.panel-body -->
+<b>OK (1 test, 1 assertions)</b></pre>
+</div> <!-- /.panel-body -->
 </div> <!-- /.panel -->
-</div>
+</div> <!-- /.col -->
 
-<div class="col-sm-4 col-lg-4">
+<div class="col-sm-3 col-lg-3">
 <p>Follow the Acceptance Testing chapter to learn how to test your
-  web application by clicking links, filling forms, as your regular users
-  do.</p>
-  <div class="list-group">
-    <a class="list-group-item" href="/docs/02-GettingStarted">A Complete Getting Started Guide</a>
-    <a class="list-group-item active" href="/docs/03-AcceptanceTests">Continue with Acceptance Tests</a>
-    <a class="list-group-item" href="/docs/01-Introduction">The difference &nbsp;between Acceptance Tests and Unit Tests</a>
-  </div>
-</div>
-  </div>
-</div>
+web application by clicking links, filling forms, as your regular users
+do.</p>
+
+<div class="list-group">
+<a class="list-group-item" href="/docs/02-GettingStarted">A Complete Getting Started Guide</a>
+<a class="list-group-item active" href="/docs/03-AcceptanceTests">Continue with Acceptance Tests</a>
+<a class="list-group-item" href="/docs/01-Introduction">The difference &nbsp;between Acceptance Tests and Unit Tests</a>
+</div> <!-- /.list-group -->
+</div> <!-- /.col -->
+</div> <!-- /.row -->
+
+</div> <!-- /.container -->

--- a/thanks.html
+++ b/thanks.html
@@ -1,56 +1,19 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="title" content="Codeception - BDD-style PHP testing framework" />
-    <title>Thanks for choosing Codeception!</title>
-    <link rel="shortcut icon" href="/images/favicon.png" />
-        <link href='http://fonts.googleapis.com/css?family=Philosopher&subset=latin' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" type="text/css" media="screen" href="http://codeception.com/css/screen.css" />
-    
-    <link title="Codeception Blog" type="application/rss+xml" rel="alternate" href="/rss.xml"/>
-
-<script type="text/javascript">
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-1899308-9']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
-  </script>
-
-
-  <meta http-equiv="REFRESH" content="3;url=http://codeception.com/codecept.phar">
-
-  </head>
-  <body>
- 
-  <div id="root">
-
-  <div class="layout">
-    <div class="content">      
-
-      <h2>Installation</h2>      
+---
+layout: bootstrap
+title: Thanks for choosing Codeception!
+meta: <meta http-equiv="REFRESH" content="3;url=http://codeception.com/codecept.phar">
+---
+<div class="container">
+  <div class="row">
+  <div class="col-xs-12 fill-thanks">
+      <h2>Installation</h2>
       <p><strong>1.</strong> Save this file into the root of desired PHP project</p>
-
       <p><strong>2.</strong> Initialize test classes inside the root of your project</p>
       <p><code>php codecept.phar bootstrap</code></p>
-
       <p><strong>3.</strong> Write your tests!</p>
       <p>Follow <a href="http://codeception.com/docs/02-GettingStarted">Getting Started Guide</a> to perform configuration and write the first test.</p>
+      <p class="small">Your download is on the way. <a href="http://codeception.com/codecept.phar">Click here</a> if you don't want to wait any longer</p>
+    </div> <!-- /col -->
+  </div> <!-- /row -->
+</div> <!-- /.container -->
 
-      <p class="small">Your download is on the way. <a href="http://codeception.com/codecept.phar">Click here</a> if you don't want to wait any longer</p>             
-
-      
-    </div>
-  </div>
-</div>
-
- 
- </body>
-</html>

--- a/thanks_php54.html
+++ b/thanks_php54.html
@@ -1,41 +1,13 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="title" content="Codeception - BDD-style PHP testing framework" />
-    <title>Thanks for choosing Codeception!</title>
-    <link rel="shortcut icon" href="/images/favicon.png" />
-        <link href='http://fonts.googleapis.com/css?family=Philosopher&subset=latin' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" type="text/css" media="screen" href="http://codeception.com/css/screen.css" />
-    
-    <link title="Codeception Blog" type="application/rss+xml" rel="alternate" href="/rss.xml"/>
+---
+layout: bootstrap
+title: Thanks for choosing Codeception!
+meta:   <meta http-equiv="REFRESH" content="3;url=http://codeception.com/php54/codecept.phar">
+---
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12 fill-thanks">
 
-<script type="text/javascript">
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-1899308-9']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
-  </script>
-
-
-  <meta http-equiv="REFRESH" content="3;url=http://codeception.com/php54/codecept.phar">
-
-  </head>
-  <body>
- 
-  <div id="root">
-
-  <div class="layout">
-    <div class="content">      
-
-      <h2>Installation</h2>      
+      <h2>Installation - PHAR PHP54</h2>
       <p><strong>1.</strong> Save this file into the root of desired PHP project</p>
 
       <p><strong>2.</strong> Initialize test classes inside the root of your project</p>
@@ -44,13 +16,7 @@
       <p><strong>3.</strong> Write your tests!</p>
       <p>Follow <a href="http://codeception.com/docs/02-GettingStarted">Getting Started Guide</a> to perform configuration and write the first test.</p>
 
-      <p class="small">Your download is on the way. <a href="http://codeception.com/codecept.phar">Click here</a> if you don't want to wait any longer</p>             
-
-      
-    </div>
-  </div>
-</div>
-
- 
- </body>
-</html>
+      <p class="small">Your download is on the way. <a href="http://codeception.com/codecept.phar">Click here</a> if you don't want to wait any longer</p>
+    </div> <!-- /col -->
+  </div> <!-- /row -->
+</div> <!-- /.container -->


### PR DESCRIPTION
Removed the container from around bootstrap.html  'content'...

<div class="container"> {{ content }} </div>

...and put it around the inner layouts. This allows the use of container-fluid, eg. to fix the hero unit on the main page. Simplifies the CSS file as well.

Clicked through all the pages I could find, didn't find any broken layouts from this change.