### PR TITLE
PHP 5.4 build is recommended for PHP 5.5 too

### DIFF
--- a/install.html
+++ b/install.html
@@ -41,7 +41,7 @@ title: Codeception Installation
           <pre><code>wget http://codeception.com/codecept.phar</code></pre>
         </p>
       </div>
-      <p><a href="http://codeception.com/php54/codecept.phar">Download phar for for PHP 5.4 and PHP < 5.5.9</a></p>
+      <p><a href="http://codeception.com/php54/codecept.phar">Download phar for PHP 5.4 and 5.5</a></p>
       <p>For PHP 5.3 <a href="/builds">use the latest version of Codeception 1.8.x</a></p>
 
 

--- a/quickstart.html
+++ b/quickstart.html
@@ -35,7 +35,7 @@ title: Quick Start Codeception
 <pre>$ wget http://codeception.com/codecept.phar<a href="/thanks" style="float:right" target="_blank">download <span class="glyphicon glyphicon-download"></span></a></pre>
 
 <!-- phar php54 -->
-<pre>$ wget http://codeception.com/php54/codecept.phar <span class="text-muted">// PHP 5.4 >= 5.5.9</span><a href="/thanks_php54" style="float:right" target="_blank">download <span class="glyphicon glyphicon-download"></span></a></pre>
+<pre>$ wget http://codeception.com/php54/codecept.phar <span class="text-muted">// PHP 5.4 and 5.5</span><a href="/thanks_php54" style="float:right" target="_blank">download <span class="glyphicon glyphicon-download"></span></a></pre>
 <p><code class="text-muted">$ alias codecept='codecept.phar'</code></p>
     <div>
     </div>


### PR DESCRIPTION
PHP 5.4 build is recommended for PHP 5.5 too, because the main build will include PHPUnit 5 which requires PHP 5.6