### PR TITLE
Mentioning MultiDb in addons.markdown

### DIFF
--- a/addons.markdown
+++ b/addons.markdown
@@ -96,6 +96,10 @@ Extension for starting and stopping built-in PHP server. Works on Windows, Mac, 
 
 Extension for automatically starting and stopping PhantomJS when running tests.
 
+#### [MultiDb](https://github.com/redmatter/Codeception-MultiDb)
+
+Extension that enables working with multiple dabatase backends and safe switching between them. It provides equivalant service as the Db module and more. Use v1.x for codeception v2.0 and v2.x for codeception v2.1.
+
 #### [DrushDb](https://github.com/pfaocle/DrushDb)
 
 DrushDb is a Codeception extension to populate and cleanup test **Drupal** sites during test runs using Drush aliases and the sql-sync command.


### PR DESCRIPTION
As discussed on Codeception/Codeception#1634.
Adding brief description of Red Matter's MultiDb module which is available on packagist.org as `redmatter/codeception-multidb`.