### PR TITLE
Alternative link for PHPTest.club

### DIFF
--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -116,7 +116,7 @@
                             <li><a href="/credits"><strong>Credits</strong></a></li>
                             <li><a href="/addons">Addons</a></li>
                             <li role="separator" class="divider"></li>
-                            <li><a href="http://phptest.club/category/codeception">Forum @ PHPTestClub</a></li>
+                            <li><a href="http://phptest.club/latest">Forum @ PHPTestClub</a></li>
                             <li><a href="http://automated-testing.info/category/codeception">Russian Forum @ AT.info</a></li>
                             <li><a href="http://stackoverflow.com/questions/tagged/codeception">StackOverflow</a></li>
                             <li><a href="https://gitter.im/codeception/codeception/">Chat @ Gitter</a></li>


### PR DESCRIPTION
Instead of sending to the Codeception Category of PHPTest.club I would suggest to send this link to the latest updates, regardless if they are from Codeception category or from others like "Selenium" category.

I'm suggesting the change because I created this topic http://phptest.club/t/firefox-47-and-new-driver-marionette/916/1 that is interesting for Codeception users however is not visible in the link where Codeception.com sends you because is not in "codeception" category but under "selenium category. With the new link the person using the link at codeception.com will get to the latest messages page.