### PR TITLE
Update 06-ReusingTestCode.md

### DIFF
--- a/docs/06-ReusingTestCode.md
+++ b/docs/06-ReusingTestCode.md
@@ -148,7 +148,7 @@ Let's improve code of our `login` method by making it executed only once for the
 
 {% endhighlight %}
 
-Please note that session restoration only works for `WebDriver` and `PhpBrowser` modules (modules implementing `Codeception\Lib\Interfaces\SessionSnapshot`) 
+Please note that session restoration only works for `WebDriver` module (modules implementing `Codeception\Lib\Interfaces\SessionSnapshot`) 
 
 ## StepObjects
 


### PR DESCRIPTION
doc here is incorrect:
http://codeception.com/docs/06-ReusingTestCode#Session-Snapshot

at least for current stable version (2.2.2)
confirmed by [StackOverFlow post](http://stackoverflow.com/a/33278142/2314626)

unfortunately even the file is in git, the commit messages are ["auto updated" nonsense](https://github.com/Codeception/codeception.github.com/commits/master/docs/06-ReusingTestCode.md)

the actual change claiming that was added in:
https://github.com/Codeception/codeception.github.com/commit/870eed4bf78fe866bda0a238aab13afb2c43a9c2#diff-6b2c7dba035ec033db6d813f619defc0

also the [README.md](https://github.com/Codeception/codeception.github.com#codeception-site) does not give any indication where the "auto-update" comes from, but encourages to submit PR