### PR TITLE
CSS Fixes

### DIFF
--- a/css/codeception.css
+++ b/css/codeception.css
@@ -259,15 +259,6 @@ ul.navbar-nav {
 	margin: 0 -15px;
 }
 
-.navbar-nav .dropdown-menu, .navbar-nav .dropdown-menu a {
-	color: #999;
-}
-
-.navbar-nav .dropdown-menu a:hover {
-	background-color: inherit;
-	color: #fff;
-}
-
 .row.home{
 	padding-top:225px;
 }
@@ -397,6 +388,15 @@ ul.navbar-nav {
 	body #home-hero h1{
 		padding-top:0px;
 		font-size: 60px;
+	}
+
+	.navbar-nav .dropdown-menu, .navbar-nav .dropdown-menu a {
+		color: #999;
+	}
+
+	.navbar-nav .dropdown-menu a:hover {
+		background-color: inherit;
+		color: #fff;
 	}
 }
 

--- a/css/codeception.css
+++ b/css/codeception.css
@@ -259,6 +259,15 @@ ul.navbar-nav {
 	margin: 0 -15px;
 }
 
+.navbar-nav .dropdown-menu, .navbar-nav .dropdown-menu a {
+	color: #999;
+}
+
+.navbar-nav .dropdown-menu a:hover {
+	background-color: inherit;
+	color: #fff;
+}
+
 .row.home{
 	padding-top:225px;
 }
@@ -387,6 +396,7 @@ ul.navbar-nav {
 
 	body #home-hero h1{
 		padding-top:0px;
+		font-size: 60px;
 	}
 }
 
@@ -573,4 +583,11 @@ ul.navbar-nav {
 
 .carousel-control.right {
 	background: none !important;
+}
+
+/**
+ * Bootstrap override
+ */
+.navbar-collapse {
+	max-height: none;
 }


### PR DESCRIPTION
Added nicer styling for nav menu on mobile, making it more readable.

Scale down h1 tag on homepage for smaller width devices to prevent
overflow of page content.