### PR TITLE
Add Config module to addons list

### DIFF
--- a/addons.markdown
+++ b/addons.markdown
@@ -31,6 +31,10 @@ Official CakePHP 3 module for Codeception.
 
 Integrate Codeception to CakePHP v2.* projects
 
+#### [Config](https://github.com/JustBlackBird/codeception-config-module)
+
+Loads params from Codeception config and pass them to test scenarios.
+
 #### [Date/Time](https://github.com/nathanmac/datetime-codeception-module)
 
 This module provides additional helpers for your test to help with date and time comparisons.


### PR DESCRIPTION
I've created a tiny module which expose params from Codeception config to test scenarios and offer it to be added to Codeception's addons list.