### PR TITLE
Fix phar download links

### DIFF
--- a/thanks_php5.html
+++ b/thanks_php5.html
@@ -16,7 +16,7 @@ meta:   <meta http-equiv="REFRESH" content="3;url=http://codeception.com/php5/co
       <p><strong>3.</strong> Write your tests!</p>
       <p>Follow <a href="http://codeception.com/docs/02-GettingStarted">Getting Started Guide</a> to perform configuration and write the first test.</p>
 
-      <p class="small">Your download is on the way. <a href="http://codeception.com/codecept.phar">Click here</a> if you don't want to wait any longer</p>
+      <p class="small">Your download is on the way. <a href="http://codeception.com/php5/codecept.phar">Click here</a> if you don't want to wait any longer</p>
     </div> <!-- /col -->
   </div> <!-- /row -->
 </div> <!-- /.container -->

--- a/thanks_php54.html
+++ b/thanks_php54.html
@@ -16,7 +16,7 @@ meta:   <meta http-equiv="REFRESH" content="3;url=http://codeception.com/php54/c
       <p><strong>3.</strong> Write your tests!</p>
       <p>Follow <a href="http://codeception.com/docs/02-GettingStarted">Getting Started Guide</a> to perform configuration and write the first test.</p>
 
-      <p class="small">Your download is on the way. <a href="http://codeception.com/codecept.phar">Click here</a> if you don't want to wait any longer</p>
+      <p class="small">Your download is on the way. <a href="http://codeception.com/php54/codecept.phar">Click here</a> if you don't want to wait any longer</p>
     </div> <!-- /col -->
   </div> <!-- /row -->
 </div> <!-- /.container -->


### PR DESCRIPTION
I updated manual download links in thanks pages to match links used in Refresh header.
Please squash commits when merging.

Closes https://github.com/Codeception/Codeception/issues/4443