### PR TITLE
Fix Codeception license URL

### DIFF
--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -220,7 +220,7 @@
                     <li><a href="/changelog">Releases</a></li>
                     <li><a href="http://sdclabs.com/codeception?utm_source=codeception.com&utm_medium=bottom_menu&utm_term=link&utm_campaign=reference" >Enterprise Support</a></li>
                     <li><a href="http://sdclabs.com/trainings?utm_source=codeception.com&utm_medium=bottom_menu&utm_term=link&utm_campaign=reference" >Trainings</a></li>                  
-                    <li><a href="https://github.com/Codeception/Codeception/blob/master/LICENSE">License</a></li>
+                    <li><a href="https://github.com/Codeception/Codeception/blob/2.5/LICENSE</a></li>
                 </ul>
 
 

--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -220,7 +220,7 @@
                     <li><a href="/changelog">Releases</a></li>
                     <li><a href="http://sdclabs.com/codeception?utm_source=codeception.com&utm_medium=bottom_menu&utm_term=link&utm_campaign=reference" >Enterprise Support</a></li>
                     <li><a href="http://sdclabs.com/trainings?utm_source=codeception.com&utm_medium=bottom_menu&utm_term=link&utm_campaign=reference" >Trainings</a></li>                  
-                    <li><a href="https://github.com/Codeception/Codeception/blob/2.5/LICENSE</a></li>
+                    <li><a href="https://github.com/Codeception/Codeception/blob/3.0/LICENSE</a></li>
                 </ul>
 
 


### PR DESCRIPTION
Since Codeception's default branch is not ```master``` but ```2.5```, make the license point to it instead of pointing to a 404 error page.