### PR TITLE
Update config for Step decorators

### DIFF
--- a/docs/08-Customization.md
+++ b/docs/08-Customization.md
@@ -358,11 +358,11 @@ List of available step decorators:
 Step decorators can be added to suite config inside `steps` block:
 
 {% highlight yaml %}
-yml
-step_decorators:
-    - Codeception/Step/TryTo
-    - Codeception/Step/Retry
-    - Codeception/Step/ConditionalAssertion
+steps:
+    step_decorators:
+        - Codeception/Step/TryTo
+        - Codeception/Step/Retry
+        - Codeception/Step/ConditionalAssertion
 
 {% endhighlight %}
 


### PR DESCRIPTION
Following a [discussion on Slack](https://codeception.slack.com/archives/C93B93AUT/p1556812096004700)
- Remove extra `yml`
- Add `steps:` to make the example more explicit.