### PR TITLE
Remove multidb module and extension in the doc

### DIFF
--- a/_data/extensions.yml
+++ b/_data/extensions.yml
@@ -27,10 +27,6 @@
   description: The reporter with a progress bar
   image: /images/extensions/codeception-progress-reporter.png  
 
-- name: MultiDb
-  link: http://github.com/redmatter/Codeception-MultiDb
-  description: Extension that enables working with multiple dabatase backends and safe switching between them. It provides equivalant service as the Db module and more. Use v1.x for codeception v2.0 and v2.x for codeception v2.1.
-
 - name: DrushDb
   link: http://github.com/pfaocle/DrushDb
   image: https://www.drupal.org/files/druplicon-small.png  

--- a/_data/modules.yml
+++ b/_data/modules.yml
@@ -114,10 +114,6 @@
   link: https://github.com/mendicm/css-regression
   description: CSS / Visual regression tests integrated in Codeception. This module can be used to compare the current representation of a website element with an expected based on a reference image. This module does not require any JavaScript injections in your website and works with viewport screenshots (chromedriver). Compatible with WebDriver and AngularJS modules.  
 
-- name: MultiDb
-  link: https://github.com/iamdevice/codeception-multidb
-  description: Extension or work with multiple databases and switch between them. Based on original Db module. Make for codeception v.2.2
-   
 - name: Mountebank
   link: https://github.com/meare/codeception-mountebank
   description: Stub and mck external services with mountebank


### PR DESCRIPTION
Hello,

Since Codeception 2.5.0 (Sept 2018) multi database is in the code of codeception.

We don't need anymore a module or extension to manage more than one database.

So I think we should remove the module and extension in the documentation. And this module https://github.com/iamdevice/codeception-multidb is not updated since 1 year.

