### PR TITLE
Fixed incorrect argument type for staticPages test

### DIFF
--- a/docs/07-AdvancedUsage.md
+++ b/docs/07-AdvancedUsage.md
@@ -290,7 +290,7 @@ class PageCest
    /**
     * @dataProvider pageProvider
     */
-    public function staticPages(AcceptanceTester $I, \Codeception\Example $example)
+    public function staticPages(AcceptanceTester $I, array $example)
     {
         $I->amOnPage($example['url']);
         $I->see($example['title'], 'h1');


### PR DESCRIPTION
Fixed incorrect argument type for `staticPages` test with dataProvider