### PR TITLE
Fix inconsistent name

### DIFF
--- a/docs/02-GettingStarted.md
+++ b/docs/02-GettingStarted.md
@@ -120,7 +120,7 @@ Then we are sent to a user page, where we see the text `Hello, %username%`. Let'
 <?php
 class SigninCest
 {
-    public function loginSuccessfully(AcceptanceTester $I)
+    public function signInSuccessfully(AcceptanceTester $I)
     {
         $I->amOnPage('/login');
         $I->fillField('Username','davert');


### PR DESCRIPTION
Other places in this page mention the name `signInSuccessfully`, only this definition use `loginSuccessfully`.