### PR TITLE
Fixing some errors on documentation php examples

### DIFF
--- a/docs/01-Introduction.md
+++ b/docs/01-Introduction.md
@@ -49,7 +49,7 @@ With acceptance tests, you can be confident that users, following all the define
 
 #### Sample acceptance test
 
-{% highlight php %}
+``` php
 
 <?php
 $I->amOnPage('/');
@@ -59,8 +59,7 @@ $I->submitForm('#signup', [
   'email' => 'miles@davis.com'
 ]);
 $I->see('Thank you for Signing Up!');
-
-{% endhighlight %}
+```
 
 ### Functional Tests
 
@@ -73,7 +72,7 @@ For functional tests, your application needs to be structured in order to run in
 
 #### Sample functional test
 
-{% highlight php %}
+``` php
 
 <?php
 $I->amOnPage('/');
@@ -82,8 +81,7 @@ $I->submitForm('#signup', ['username' => 'MilesDavis', 'email' => 'miles@davis.c
 $I->see('Thank you for Signing Up!');
 $I->seeEmailSent('miles@davis.com', 'Thank you for registration');
 $I->seeInDatabase('users', ['email' => 'miles@davis.com']);
-
-{% endhighlight %}
+```
 
 > This looks very similar to acceptance tests. The behavior is the same, however, the test is executed inside PHP without launching a browser.
 
@@ -103,7 +101,7 @@ The better you understand the testing scenario, the faster you can update it for
 
 #### Sample integration test
 
-{% highlight php %}
+``` php
 
 <?php
 public function testSavingUser()
@@ -118,8 +116,7 @@ public function testSavingUser()
       'surname' => 'Davis'
     ]);
 }
-
-{% endhighlight %}
+```
 
 ## Conclusion
 


### PR DESCRIPTION
I would like to read the introduction, but it had some format errors and I'd try to resolve. I hope it helps