### PR TITLE
Disable link to forum

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -38,11 +38,13 @@ layout: bootstrap
           alt="Total Downloads" data-canonical-src="https://poser.pugx.org/codeception/codeception/downloads.png">
       </p>
 
+      <!--
       <p>
         <a href="http://phptest.club/c/codeception" class="test-forum">
           <img src="/images/phptestclub.png" alt="Community Forum"><br> Community Forum
         </a>
       </p>
+      -->
 
       <p>
         <a href="https://github.com/codeception/codeception" class="github-repository">


### PR DESCRIPTION
phptest.club server has not been available for a long time, so we should not expose the link.