### PR TITLE
Update Functional Tests page

### DIFF
--- a/docs/04-FunctionalTests.md
+++ b/docs/04-FunctionalTests.md
@@ -267,7 +267,7 @@ error_level: "E_ALL & ~E_STRICT & ~E_DEPRECATED"
 
 {% endhighlight %}
 
-`error_level` can also be set globally in `codeception.yml` file.
+`error_level` can also be set globally in `codeception.yml` file. In order to do that, you need to specify `error_level` as a part of `settings`. For more information, see [Global Configuration](https://codeception.com/docs/reference/Configuration).
 
 ## Conclusion
 


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/pull/5237

The page [Functional Tests](https://codeception.com/docs/04-FunctionalTests#Error-Reporting) mentions

> error_level can also be set globally in codeception.yml file.

but it does not mention that it needs to be under `settings` otherwise it would not work