### PR TITLE
Add note that Rest API testing requires the module-rest package

### DIFF
--- a/docs/10-APITesting.md
+++ b/docs/10-APITesting.md
@@ -19,6 +19,8 @@ We will put all the api tests there.
 
 ## REST API
 
+> **NOTE:** REST API testing requires the `codeception/module-rest` package to be installed.
+
 The REST web service is accessed via HTTP with standard methods: `GET`, `POST`, `PUT`, `DELETE`. They allow users to receive and manipulate entities from the service. Accessing a WebService requires an HTTP client, so for using it you need the module `PhpBrowser` or one of framework modules set up. For example, we can use the `Symfony` module for Symfony2 applications in order to ignore web server and test web service internally.
 
 Configure modules in `api.suite.yml`:


### PR DESCRIPTION
After working through [the REST API testing documentation](https://codeception.com/docs/10-APITesting) and attempting to run the API tests, I encountered the following error:

```console
Module REST is not installed.
Use Composer to install corresponding package:

composer require codeception/module-rest --dev
```

This change updates the REST section of the API documentation to cover this requirement, so that it's not discovered when running the API tests.