### PR TITLE
Linking to Symfony Module

### DIFF
--- a/_includes/for.html
+++ b/_includes/for.html
@@ -1,6 +1,6 @@
 <div class="row casestudy">
   <div class="col-sm-4">
-    <a href="/for/symfony" class="item img-thumbnail bg-white item--symfony">
+    <a href="https://codeception.com/docs/modules/Symfony" class="item img-thumbnail bg-white item--symfony">
       <div>
         <img src="/images/frameworks/symfony.svg" alt="Symfony">
         <h4>Symfony</h4>

--- a/_includes/for.html
+++ b/_includes/for.html
@@ -1,6 +1,6 @@
 <div class="row casestudy">
   <div class="col-sm-4">
-    <a href="https://codeception.com/docs/modules/Symfony" class="item img-thumbnail bg-white item--symfony">
+    <a href="/docs/modules/Symfony" class="item img-thumbnail bg-white item--symfony">
       <div>
         <img src="/images/frameworks/symfony.svg" alt="Symfony">
         <h4>Symfony</h4>


### PR DESCRIPTION
See https://github.com/Codeception/module-symfony/pull/98#issuecomment-800446510
As long as the dropdown menu does exist, I think it's better to keep Symfony in there, in order to not give the impression that Symfony isn't supported :-)
Ultimately, the dropdown should be deleted completely (or renamed to "CMS") - see https://github.com/Codeception/module-symfony/pull/98#issue-553062458