### PR TITLE
Fix phar download accordion

### DIFF
--- a/_includes/phar.html
+++ b/_includes/phar.html
@@ -7,7 +7,7 @@
       </h4>
     </div>
 
-    <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+    <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne" href="#collapseOne">
 
       <div class="panel-collapse-body">
         <div class="row">
@@ -33,9 +33,9 @@
     </div>
   </div>
 
-  <div class="panel panel-default" data-toggle="collapse" data-parent="#accordion" aria-expanded="true"
-       aria-controls="collapseTwo">
-    <div class="panel-heading" role="tab" id="headingTwo">
+  <div class="panel panel-default">
+    <div class="panel-heading" role="tab" id="headingTwo" data-toggle="collapse" data-parent="#accordion" aria-expanded="true"
+         aria-controls="collapseTwo" href="#collapseTwo">
       <h4 class="panel-title">
         Download Codeception v4 Phar for PHP 7.2 - 8.2
       </h4>
@@ -69,7 +69,7 @@
 
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="headingThree" data-toggle="collapse" data-parent="#accordion" aria-expanded="true"
-         aria-controls="collapseThree">
+         aria-controls="collapseThree" href="#collapseThree">
       <h4 class="panel-title">
           Download Codeception v4 Phar for PHP 5.6 - 7.1
       </h4>
@@ -101,7 +101,7 @@
 
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="headingFour" data-toggle="collapse" data-parent="#accordion" aria-expanded="true"
-         aria-controls="collapseFour">
+         aria-controls="collapseFour" href="#collapseFour">
       <h4 class="panel-title">
           Install Phar Globally
       </h4>


### PR DESCRIPTION
href attributes are required for opening/closing tabs.

Second tab must be closed by default

See https://codeception.com/install