### PR TITLE
Fix duplicate sendPatch reference in ApiTesting.md

### DIFF
--- a/docs/APITesting.md
+++ b/docs/APITesting.md
@@ -129,7 +129,6 @@ To create or update data you can use other common methods:
 * `sendPut`
 * `sendPatch`
 * `sendDelete`
-* `sendPatch`
 
 To send a request with custom method use `send` action:
 


### PR DESCRIPTION
The `sendPatch` method was mentioned twice in the list of common `send*` methods in ApiTesting.md. This PR removes the duplicated entry.