### PR TITLE
Removing "Releases" from navigation bar

### DIFF
--- a/_layouts/bootstrap.html
+++ b/_layouts/bootstrap.html
@@ -119,9 +119,6 @@
                     </div>
                 </li>
                 <li>
-                    <a href="/changelog">Releases</a>
-                </li>
-                <li>
                     <a href="/blog">Blog</a>
                 </li>
                 <li class="dropdown">


### PR DESCRIPTION
I think this is way too prominent.
The page mainly is an overview of what GitHub gives you anyway - so does anybody really need this at all?
* If yes, I'll find another place
* If no, let's delete the page too! :-)

Same question for https://codeception.com/builds which is linked from the releases page.