### PR TITLE
Added documentation for the new option --disable-coverage-php

### DIFF
--- a/docs/Codecoverage.md
+++ b/docs/Codecoverage.md
@@ -92,9 +92,12 @@ All you need is to execute codeception with `--coverage` option.
 To generate a clover xml report or a tasty html report append also `--coverage-xml` and `--coverage-html` options.
 
 
-```yaml
+```bash
 php vendor/bin/codecept run --coverage --coverage-xml --coverage-html
 ```
+
+> note: If you don't need to generate default PHP coverage report (coverage.serialized) you can call `--disable-coverage-php` option.
+This option can help you reduce memory usage and fix problems with memory leak on the huge projects.
 
 XML and HTML reports are stored to the `_output` directory. The best way to review report is to open `index.html` from `tests/_output/coverage` in your browser.
 XML clover reports are used by IDEs (like PHPStorm) or Continuous Integration servers (like Jenkins).

--- a/docs/reference/Commands.md
+++ b/docs/reference/Commands.md
@@ -54,39 +54,40 @@ Arguments:
 
 Options:
  -o, --override=OVERRIDE Override config values (multiple values allowed)
- --config (-c)         Use custom path for config
- --report              Show output in compact style
- --html                Generate html with results (default: "report.html")
- --xml                 Generate JUnit XML Log (default: "report.xml")
- --phpunit-xml         Generate PhpUnit XML Log (default: "phpunit-report.xml")
- --no-redirect         Do not redirect to Composer-installed version in vendor/codeception
- --colors              Use colors in output
- --no-colors           Force no colors in output (useful to override config file)
- --silent              Only outputs suite names and final results. Almost the same as `--quiet`
- --steps               Show steps in output
- --debug (-d)          Alias for `-vv`
- --bootstrap           Execute bootstrap script before the test
- --coverage            Run with code coverage (default: "coverage.serialized")
- --coverage-html       Generate CodeCoverage HTML report in path (default: "coverage")
- --coverage-xml        Generate CodeCoverage XML report in file (default: "coverage.xml")
- --coverage-text       Generate CodeCoverage text report in file (default: "coverage.txt")
- --coverage-phpunit    Generate CodeCoverage PHPUnit report in file (default: "coverage-phpunit")
- --coverage-cobertura  Generate CodeCoverage Cobertura report in file (default: "coverage-cobertura")
- --no-exit             Don't finish with exit code
- --group (-g)          Groups of tests to be executed (multiple values allowed)
- --skip (-s)           Skip selected suites (multiple values allowed)
- --skip-group (-x)     Skip selected groups (multiple values allowed)
- --env                 Run tests in selected environments. (multiple values allowed, environments can be merged with ',')
- --fail-fast (-f)      Stop after nth failure (defaults to 1)
- --no-rebuild          Do not rebuild actor classes on start
- --help (-h)           Display this help message.
- --quiet (-q)          Do not output any message. Almost the same as `--silent`
- --verbose (-v|vv|vvv) Increase the verbosity of messages: `v` for normal output, `vv` for steps and debug, `vvv` for Codeception-internal debug
- --version (-V)        Display this application version.
- --ansi                Force ANSI output.
- --no-ansi             Disable ANSI output.
- --no-interaction (-n) Do not ask any interactive question.
- --seed                Use the given seed for shuffling tests
+ --config (-c)          Use custom path for config
+ --report               Show output in compact style
+ --html                 Generate html with results (default: "report.html")
+ --xml                  Generate JUnit XML Log (default: "report.xml")
+ --phpunit-xml          Generate PhpUnit XML Log (default: "phpunit-report.xml")
+ --no-redirect          Do not redirect to Composer-installed version in vendor/codeception
+ --colors               Use colors in output
+ --no-colors            Force no colors in output (useful to override config file)
+ --silent               Only outputs suite names and final results. Almost the same as `--quiet`
+ --steps                Show steps in output
+ --debug (-d)           Alias for `-vv`
+ --bootstrap            Execute bootstrap script before the test
+ --coverage             Run with code coverage (default: "coverage.serialized")
+ --disable-coverage-php Don't generate CodeCoverage report in raw PHP serialized format
+ --coverage-html        Generate CodeCoverage HTML report in path (default: "coverage")
+ --coverage-xml         Generate CodeCoverage XML report in file (default: "coverage.xml")
+ --coverage-text        Generate CodeCoverage text report in file (default: "coverage.txt")
+ --coverage-phpunit     Generate CodeCoverage PHPUnit report in file (default: "coverage-phpunit")
+ --coverage-cobertura   Generate CodeCoverage Cobertura report in file (default: "coverage-cobertura")
+ --no-exit              Don't finish with exit code
+ --group (-g)           Groups of tests to be executed (multiple values allowed)
+ --skip (-s)            Skip selected suites (multiple values allowed)
+ --skip-group (-x)      Skip selected groups (multiple values allowed)
+ --env                  Run tests in selected environments. (multiple values allowed, environments can be merged with ',')
+ --fail-fast (-f)       Stop after nth failure (defaults to 1)
+ --no-rebuild           Do not rebuild actor classes on start
+ --help (-h)            Display this help message.
+ --quiet (-q)           Do not output any message. Almost the same as `--silent`
+ --verbose (-v|vv|vvv)  Increase the verbosity of messages: `v` for normal output, `vv` for steps and debug, `vvv` for Codeception-internal debug
+ --version (-V)         Display this application version.
+ --ansi                 Force ANSI output.
+ --no-ansi              Disable ANSI output.
+ --no-interaction (-n)  Do not ask any interactive question.
+ --seed                 Use the given seed for shuffling tests
 
 {% endhighlight %}
 


### PR DESCRIPTION
caused by: https://github.com/Codeception/Codeception/issues/6760
caused by: https://github.com/Codeception/Codeception/pull/6761

Add some new option `--disable-coverage-php` this will not provoke BC changes
```bash
php bin/codecept run unit --coverage --coverage-html --disable-coverage-php
```