### PR TITLE
Update AdvancedUsage.md

### DIFF
--- a/docs/AdvancedUsage.md
+++ b/docs/AdvancedUsage.md
@@ -245,10 +245,10 @@ use \Codeception\Example;
 class EndpointCest
 {
 
-  #[Examples('/api', 200)]
-  #[Examples('/api/protected', 401)]
-  #[Examples('/api/not-found-url', 404)]
-  #[Examples('/api/faulty', 500)]
+  #[Examples(['/api', 200)]]
+  #[Examples(['/api/protected', 401])]
+  #[Examples(['/api/not-found-url', 404])]
+  #[Examples(['/api/faulty', 500])]
   public function checkEndpoints(ApiTester $I, Example $example)
   {
     $I->sendGet($example[0]);


### PR DESCRIPTION
If used as described in the current documentation, codeception throws an error

In Step.php line 44:
                                                                               
  Codeception\Step::__construct(): Argument #2 ($arguments) must be of type a  
  rray, string given, called in /opt/app/vendor/codeception/codeception/src/C  
  odeception/Test/Cest.php on line 89       
  
  
But it would be great if it could work without additional parentheses.