### PR TITLE
Remove E_STRICT from default error_level

### DIFF
--- a/docs/FunctionalTests.md
+++ b/docs/FunctionalTests.md
@@ -219,14 +219,14 @@ Also check all available *Public Properties* of the used modules to get full acc
 
 ## Error Reporting
 
-By default Codeception uses the `E_ALL & ~E_STRICT & ~E_DEPRECATED` error reporting level.
+By default Codeception uses the `E_ALL & ~E_DEPRECATED` error reporting level (PHP < 8.4: `E_ALL & ~E_STRICT & ~E_DEPRECATED`).
 In functional tests you might want to change this level depending on your framework's error policy.
 The error reporting level can be set in the suite configuration file:
 
 ```yaml
 actor: FunctionalTester
 ...
-error_level: E_ALL & ~E_STRICT & ~E_DEPRECATED
+error_level: E_ALL & ~E_DEPRECATED
 ```
 
 `error_level` can also be set globally in `codeception.yml` file. In order to do that, you need to specify `error_level` as a part of `settings`. For more information, see [Global Configuration](https://codeception.com/docs/reference/Configuration). Note that suite specific `error_level` value will override global value.

--- a/docs/UnitTests.md
+++ b/docs/UnitTests.md
@@ -489,14 +489,14 @@ public function testSingleton()
 
 ## Error Reporting
 
-By default Codeception uses the `E_ALL & ~E_STRICT & ~E_DEPRECATED` error reporting level.
+By default Codeception uses the `E_ALL & ~E_DEPRECATED` error reporting level (PHP < 8.4: `E_ALL & ~E_STRICT & ~E_DEPRECATED`).
 In unit tests you might want to change this level depending on your framework's error policy.
 The error reporting level can be set in the suite configuration file:
 
 ```yaml
 actor: UnitTester
 ...
-error_level: E_ALL & ~E_STRICT & ~E_DEPRECATED
+error_level: E_ALL & ~E_DEPRECATED
 ```
 
 `error_level` can also be set globally in `codeception.yml` file. In order to do that, you need to specify `error_level` as a part of `settings`. For more information, see [Global Configuration](https://codeception.com/docs/reference/Configuration). Note that suite specific `error_level` value will override global value.

--- a/docs/reference/Configuration.md
+++ b/docs/reference/Configuration.md
@@ -97,7 +97,7 @@ Possible settings:
     * PhpStorm: `'phpstorm://open?file=%%file%%&line=%%line%%'`
     * Visual Studio Code: `'vscode://file/%%file%%:%%line%%'`
     * Atom: `'atom://core/open/file?filename=%%file%%&line=%%line%%'`
-* `error_level: E_ALL & ~E_STRICT & ~E_DEPRECATED`: Set the error_reporting level. You can specify either a predefined constant or an integer value, see https://www.php.net/manual/en/function.error-reporting.php and https://www.php.net/manual/en/errorfunc.constants.php
+* `error_level: E_ALL & ~E_DEPRECATED`: Set the error_reporting level. You can specify either a predefined constant or an integer value, see https://www.php.net/manual/en/function.error-reporting.php and https://www.php.net/manual/en/errorfunc.constants.php. For PHP < 8.4 `E_ALL & ~E_STRICT & ~E_DEPRECATED` is used by default.
 * `memory_limit: 1024M`: Tests (especially functional) can take a lot of memory. We set a high limit for them by default.
 * `lint: true`: Enable/disable syntax of test files before loading. For PHP < 7 `exec('php -l')` is used. Disable if you need to speed up tests execution.
 * `log_incomplete_skipped: false`: Log the incomplete and skipped tests into junit report ,see https://phpunit.de/manual/current/en/appendixes.configuration.html Section logging > junit


### PR DESCRIPTION
The default value for PHP > 8.3 was changed in https://github.com/Codeception/Codeception/pull/6802 because the constant `E_STRICT` is deprecated since PHP 8.4.